### PR TITLE
Update build SDK and targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+﻿name: Build
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      dotnet-version: 8.0.x
+    strategy:
+      matrix:
+        configuration: ['Debug', 'Release']
+
+    steps:
+    - name: Check out the project
+      uses: actions/checkout@v4
+    - name: Set up .NET ${{env.dotnet-version}}
+      uses: actions/setup-dotnet@v4
+      id: setup
+      with:
+        dotnet-version: ${{env.dotnet-version}}
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
+      run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
+    - name: Run build script (${{matrix.configuration}})
+      run: pwsh ./build-package.ps1 -WithBinLog -Configuration ${{matrix.configuration}}
+    - name: "Artifact: MSBuild Logs"
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: MSBuild Logs (${{matrix.configuration}})
+        path: msbuild.*.binlog
+    - name: "Artifact: NuGet Packages"
+      uses: actions/upload-artifact@v3
+      with:
+        name: NuGet Packages (${{matrix.configuration}})
+        path: "output/package/${{matrix.configuration}}/*.*nupkg"
+    - name: Publish (NuGet - GitHub Packages)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.*nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
+    - name: Publish (NuGet - nuget.org)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,6 @@
   <!-- Package Versions -->
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2021.3.0" />
-    <PackageVersion Include="System.Memory" Version="4.5.4" />
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
 </Project>

--- a/MetaBrainz.Common.sln
+++ b/MetaBrainz.Common.sln
@@ -9,7 +9,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Fi
 		appveyor.yml = appveyor.yml
 		build-package.ps1 = build-package.ps1
 		Directory.Packages.props = Directory.Packages.props
-		global.json = global.json
 		LICENSE.md = LICENSE.md
 		README.md = README.md
 	EndProjectSection

--- a/MetaBrainz.Common.sln
+++ b/MetaBrainz.Common.sln
@@ -6,7 +6,6 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Files", "{96AE5FBC-DDA2-423D-8A21-FDC6A97015D4}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		appveyor.yml = appveyor.yml
 		build-package.ps1 = build-package.ps1
 		Directory.Packages.props = Directory.Packages.props
 		LICENSE.md = LICENSE.md
@@ -22,6 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{1E672E
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Actions", "Actions", "{23BF0B90-7393-4926-B495-32AAB375102C}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\release-drafter.yml = .github\workflows\release-drafter.yml
 		.github\workflows\update-labels.yml = .github\workflows\update-labels.yml
 	EndProjectSection

--- a/MetaBrainz.Common/MetaBrainz.Common.csproj
+++ b/MetaBrainz.Common/MetaBrainz.Common.csproj
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MetaBrainz.Build.Sdk">
+<Project Sdk="MetaBrainz.Build.Sdk/3.0.0">
 
   <PropertyGroup>
+    <Authors>Zastai</Authors>
     <Title>Common Utilities</Title>
     <Description>This package provides general utility classes used by other MetaBrainz packages.</Description>
-    <PackageCopyrightYears>2022</PackageCopyrightYears>
+    <PackageCopyrightOwners>Tim Van Holder</PackageCopyrightOwners>
+    <PackageCopyrightYears>2022, 2023</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.Common</PackageRepositoryName>
     <PackageTags>MetaBrainz</PackageTags>
     <Version>1.0.1-pre</Version>
@@ -12,8 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" IncludeAssets="compile" PrivateAssets="all" />
-    <PackageReference Include="System.Memory" />
-    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/MetaBrainz.Common/RateLimitInfo.cs
+++ b/MetaBrainz.Common/RateLimitInfo.cs
@@ -71,7 +71,7 @@ public readonly struct RateLimitInfo {
     if (text is null) {
       return null;
     }
-    return long.TryParse(text, out var value) ? UnixTime.Convert(value) : null;
+    return long.TryParse(text, out var value) ? DateTimeOffset.FromUnixTimeSeconds(value) : null;
   }
 
 }

--- a/MetaBrainz.Common/TextUtils.cs
+++ b/MetaBrainz.Common/TextUtils.cs
@@ -12,13 +12,8 @@ public static class TextUtils {
   /// <summary>Decodes all the bytes in the specified span as a string, using the UTF-8 character set.</summary>
   /// <param name="bytes">A read-only byte span to decode to a Unicode string.</param>
   /// <returns>A string that contains the decoded bytes from the provided read-only span.</returns>
-  public static string DecodeUtf8(ReadOnlySpan<byte> bytes) {
-#if NETFRAMEWORK || NETSTANDARD2_0 // No Span-based API
-    return Encoding.UTF8.GetString(bytes.ToArray());
-#else
-    return Encoding.UTF8.GetString(bytes);
-#endif
-  }
+  [Obsolete("Call Encoding.UTF8.GetString() instead.")]
+  public static string DecodeUtf8(ReadOnlySpan<byte> bytes) => Encoding.UTF8.GetString(bytes);
 
   /// <summary>Formats a string, including extra handling if it's multiline.</summary>
   /// <param name="text">The string to format. Trailing line breaks are discarded.</param>

--- a/MetaBrainz.Common/UnixTime.cs
+++ b/MetaBrainz.Common/UnixTime.cs
@@ -6,59 +6,35 @@ namespace MetaBrainz.Common;
 
 /// <summary>Utility class for working with Unix time values (seconds since 1970-01-01T00:00:00).</summary>
 [PublicAPI]
+[Obsolete($"Use {nameof(DateTimeOffset)} instead.")]
 public static class UnixTime {
 
-#if NET || NETSTANDARD2_1_OR_GREATER // Unix Time support available
-
   /// <summary>The epoch for Unix time values (1970-01-01T00:00:00Z).</summary>
+  [Obsolete($"Use {nameof(DateTimeOffset)}.{nameof(DateTimeOffset.UnixEpoch)} instead.")]
   public static readonly DateTimeOffset Epoch = DateTimeOffset.UnixEpoch;
 
   /// <summary>Computes the Unix time value corresponding to the specified date/time.</summary>
   /// <param name="value">The date/time to convert to a Unix time value.</param>
   /// <returns>The corresponding Unix time value.</returns>
+  [Obsolete($"Use {nameof(DateTimeOffset)}.{nameof(DateTimeOffset.ToUnixTimeSeconds)} instead.")]
   public static long Convert(DateTimeOffset value) => value.ToUnixTimeSeconds();
 
   /// <summary>Computes the Unix time value corresponding to the specified date/time.</summary>
   /// <param name="value">The date/time to convert to a Unix time value.</param>
   /// <returns>The corresponding Unix time value.</returns>
+  [Obsolete($"Use {nameof(DateTimeOffset)}.{nameof(DateTimeOffset.ToUnixTimeSeconds)} instead.")]
   public static long? Convert(DateTimeOffset? value) => value?.ToUnixTimeSeconds();
 
   /// <summary>Computes the date/time corresponding to the specified Unix time value.</summary>
   /// <param name="value">The Unix time value to convert to a date/time.</param>
   /// <returns>The corresponding date/time.</returns>
+  [Obsolete($"Use {nameof(DateTimeOffset)}.{nameof(DateTimeOffset.FromUnixTimeSeconds)} instead.")]
   public static DateTimeOffset Convert(long value) => DateTimeOffset.FromUnixTimeSeconds(value);
 
   /// <summary>Computes the date/time corresponding to the specified Unix time value.</summary>
   /// <param name="value">The Unix time value to convert to a date/time.</param>
   /// <returns>The corresponding date/time.</returns>
+  [Obsolete($"Use {nameof(DateTimeOffset)}.{nameof(DateTimeOffset.FromUnixTimeSeconds)} instead.")]
   public static DateTimeOffset? Convert(long? value) => value.HasValue ? DateTimeOffset.FromUnixTimeSeconds(value.Value) : null;
-
-#else
-
-  /// <summary>The epoch for Unix time values (1970-01-01T00:00:00Z).</summary>
-  public static readonly DateTimeOffset Epoch = new(621355968000000000L, TimeSpan.Zero);
-
-  /// <summary>Computes the Unix time value corresponding to the specified date/time.</summary>
-  /// <param name="value">The date/time to convert to a Unix time value.</param>
-  /// <returns>The corresponding Unix time value.</returns>
-  public static long Convert(DateTimeOffset value) => (long) (value - UnixTime.Epoch).TotalSeconds;
-
-  /// <summary>Computes the Unix time value corresponding to the specified date/time.</summary>
-  /// <param name="value">The date/time to convert to a Unix time value.</param>
-  /// <returns>The corresponding Unix time value.</returns>
-  public static long? Convert(DateTimeOffset? value)
-    => value.HasValue ? (long?) (value.Value - UnixTime.Epoch).TotalSeconds : null;
-
-  /// <summary>Computes the date/time corresponding to the specified Unix time value.</summary>
-  /// <param name="value">The Unix time value to convert to a date/time.</param>
-  /// <returns>The corresponding date/time.</returns>
-  public static DateTimeOffset Convert(long value) => UnixTime.Epoch.AddSeconds(value);
-
-  /// <summary>Computes the date/time corresponding to the specified Unix time value.</summary>
-  /// <param name="value">The Unix time value to convert to a date/time.</param>
-  /// <returns>The corresponding date/time.</returns>
-  public static DateTimeOffset? Convert(long? value) => value.HasValue ? UnixTime.Epoch.AddSeconds(value.Value) : null;
-
-#endif
 
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
-# MetaBrainz.Common [![Build Status](https://img.shields.io/appveyor/build/zastai/metabrainz-common)](https://ci.appveyor.com/project/Zastai/metabrainz-common) [![NuGet Version](https://img.shields.io/nuget/v/MetaBrainz.Common)](https://www.nuget.org/packages/MetaBrainz.Common)
+# MetaBrainz.Common [![Build Status][CI-S]][CI-L] [![NuGet Package Version][NuGet-S]][NuGet-L]
 
 General helper classes, for use by the other `MetaBrainz.*` packages.
+
+[CI-S]: https://github.com/Zastai/MetaBrainz.Common/actions/workflows/build.yml/badge.svg
+[CI-L]: https://github.com/Zastai/MetaBrainz.Common/actions/workflows/build.yml
+
+[NuGet-S]: https://img.shields.io/nuget/v/MetaBrainz.Common
+[NuGet-L]: https://www.nuget.org/packages/MetaBrainz.Common

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,0 @@
-version: 'Build #{build}'
-image: Visual Studio 2022
-build_script:
-  - ps: .\build-package.ps1 -Configuration Debug
-after_build:
-  - ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,0 @@
-{
-  "msbuild-sdks": {
-    "MetaBrainz.Build.Sdk" : "2.1.2"
-  }
-}


### PR DESCRIPTION
This reduces the supported targets to just `net6.0` and `net8.0`, allowing some cleanup of code (and making some parts obsolete).

It also switches CI from AppVeyor to GitHub Actions.