### PR TITLE
Add `ResultOf` overloads for `ValueTask`

### DIFF
--- a/MetaBrainz.Common/AsyncUtils.cs
+++ b/MetaBrainz.Common/AsyncUtils.cs
@@ -18,4 +18,14 @@ public static class AsyncUtils {
   /// <returns>The value returned by the task when it completes.</returns>
   public static T ResultOf<T>(Task<T> task) => task.ConfigureAwait(false).GetAwaiter().GetResult();
 
+  /// <summary>Synchronously awaits a task.</summary>
+  /// <param name="task">The task to await.</param>
+  public static void ResultOf(ValueTask task) => task.ConfigureAwait(false).GetAwaiter().GetResult();
+
+  /// <summary>Synchronously awaits a task.</summary>
+  /// <param name="task">The task to await.</param>
+  /// <typeparam name="T">The return type for the task.</typeparam>
+  /// <returns>The value returned by the task when it completes.</returns>
+  public static T ResultOf<T>(ValueTask<T> task) => task.ConfigureAwait(false).GetAwaiter().GetResult();
+
 }

--- a/MetaBrainz.Common/MetaBrainz.Common.csproj
+++ b/MetaBrainz.Common/MetaBrainz.Common.csproj
@@ -9,7 +9,7 @@
     <PackageCopyrightYears>2022, 2023</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.Common</PackageRepositoryName>
     <PackageTags>MetaBrainz</PackageTags>
-    <Version>1.0.1-pre</Version>
+    <Version>2.0.0-pre</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This also bumps the major version (minor would have been enough for this change, but the SDK and target change warrant a major version bump).