### PR TITLE
Update the build SDK to version 3.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
       run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
     - name: Run build script (${{matrix.configuration}})
-      run: pwsh ./build-package.ps1 -WithBinLog -Configuration ${{matrix.configuration}}
+      run: pwsh ./build-package.ps1 -ContinuousIntegration -WithBinLog -Configuration ${{matrix.configuration}}
     - name: "Artifact: MSBuild Logs"
       uses: actions/upload-artifact@v3
       if: failure()
@@ -46,7 +46,7 @@ jobs:
         path: "output/package/${{matrix.configuration}}/*.*nupkg"
     - name: Publish (NuGet - GitHub Packages)
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
-      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.*nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
     - name: Publish (NuGet - nuget.org)
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
       run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/MetaBrainz.Common/MetaBrainz.Common.csproj
+++ b/MetaBrainz.Common/MetaBrainz.Common.csproj
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MetaBrainz.Build.Sdk/3.0.0">
+<Project>
+
+  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.0" />
 
   <PropertyGroup>
     <Authors>Zastai</Authors>
@@ -10,6 +12,10 @@
     <PackageRepositoryName>MetaBrainz.Common</PackageRepositoryName>
     <PackageTags>MetaBrainz</PackageTags>
     <Version>2.0.0-pre</Version>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AssemblyIsComVisible>false</AssemblyIsComVisible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MetaBrainz.Common/Properties/AssemblyInfo.cs
+++ b/MetaBrainz.Common/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.InteropServices;
-
-[assembly: ComVisible(false)]

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -3,6 +3,7 @@
 [CmdletBinding()]
 param (
   [string] $Configuration = 'Release',
+  [switch] $ContinuousIntegration = $false,
   [switch] $WithBinLog = $false
 )
 
@@ -41,7 +42,15 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "Building the solution (Configuration: $Configuration)..."
-dotnet build $opts --no-restore "-c:$Configuration" '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+$props = @()
+if ($ContinuousIntegration) {
+  $props += '-p:ContinuousIntegrationBuild=true'
+  $props += '-p:Deterministic=true'
+}
+if ($Configuration -eq 'Debug') {
+  $props += '-p:DebugMessageImportance=high'
+}
+dotnet build $opts --no-restore "-c:$Configuration" $props
 Complete-BuildStep 'build'
 if ($LASTEXITCODE -ne 0) {
   Write-Error "SOLUTION BUILD FAILED"

--- a/public-api/MetaBrainz.Common.net6.0.cs.md
+++ b/public-api/MetaBrainz.Common.net6.0.cs.md
@@ -1,0 +1,139 @@
+﻿# API Reference: MetaBrainz.Common
+
+## Assembly Attributes
+
+```cs
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+```
+
+## Namespace: MetaBrainz.Common
+
+### Type: AsyncUtils
+
+```cs
+public static class AsyncUtils {
+
+  public static void ResultOf(System.Threading.Tasks.Task task);
+
+  public static void ResultOf(System.Threading.Tasks.ValueTask task);
+
+  public static T ResultOf<T>(System.Threading.Tasks.Task<T> task);
+
+  public static T ResultOf<T>(System.Threading.Tasks.ValueTask<T> task);
+
+}
+```
+
+### Type: HttpError
+
+```cs
+public class HttpError : System.Exception {
+
+  string Message {
+    public override get;
+  }
+
+  string? Reason {
+    public get;
+  }
+
+  System.Net.HttpStatusCode Status {
+    public get;
+  }
+
+  public HttpError(System.Net.Http.HttpResponseMessage response);
+
+  public HttpError(System.Net.HttpStatusCode status, string? reason, System.Exception? cause = null);
+
+}
+```
+
+### Type: HttpUtils
+
+```cs
+public static class HttpUtils {
+
+  public const string UnknownAssemblyName = "*Unknown Assembly*";
+
+  public static System.Net.Http.Headers.ProductInfoHeaderValue CreateUserAgentHeader<T>();
+
+  public static System.Net.Http.HttpResponseMessage EnsureSuccessful(this System.Net.Http.HttpResponseMessage response);
+
+  public static System.Threading.Tasks.ValueTask<System.Net.Http.HttpResponseMessage> EnsureSuccessfulAsync(this System.Net.Http.HttpResponseMessage response, System.Threading.CancellationToken cancellationToken = default);
+
+  public static string GetContentEncoding(this System.Net.Http.Headers.HttpContentHeaders contentHeaders);
+
+  public static string GetStringContent(this System.Net.Http.HttpResponseMessage response);
+
+  public static System.Threading.Tasks.Task<string> GetStringContentAsync(this System.Net.Http.HttpResponseMessage response, System.Threading.CancellationToken cancellationToken = default);
+
+}
+```
+
+### Type: RateLimitInfo
+
+```cs
+public readonly struct RateLimitInfo {
+
+  int? AllowedRequests {
+    public get;
+  }
+
+  System.DateTimeOffset LastRequest {
+    public get;
+  }
+
+  int? RemainingRequests {
+    public get;
+  }
+
+  System.DateTimeOffset? ResetAt {
+    public get;
+  }
+
+  int? ResetIn {
+    public get;
+  }
+
+  public RateLimitInfo(System.Net.Http.Headers.HttpResponseHeaders headers);
+
+}
+```
+
+### Type: TextUtils
+
+```cs
+public static class TextUtils {
+
+  [System.ObsoleteAttribute("Call Encoding.UTF8.GetString() instead.")]
+  public static string DecodeUtf8(System.ReadOnlySpan<byte> bytes);
+
+  public static string FormatMultiLine(string text, string prefix = "<<", string suffix = ">>", string separator = "\n  ");
+
+}
+```
+
+### Type: UnixTime
+
+```cs
+[System.ObsoleteAttribute("Use DateTimeOffset instead.")]
+public static class UnixTime {
+
+  [System.ObsoleteAttribute("Use DateTimeOffset.UnixEpoch instead.")]
+  public static readonly System.DateTimeOffset Epoch;
+
+  [System.ObsoleteAttribute("Use DateTimeOffset.ToUnixTimeSeconds instead.")]
+  public static long Convert(System.DateTimeOffset value);
+
+  [System.ObsoleteAttribute("Use DateTimeOffset.ToUnixTimeSeconds instead.")]
+  public static long? Convert(System.DateTimeOffset? value);
+
+  [System.ObsoleteAttribute("Use DateTimeOffset.FromUnixTimeSeconds instead.")]
+  public static System.DateTimeOffset Convert(long value);
+
+  [System.ObsoleteAttribute("Use DateTimeOffset.FromUnixTimeSeconds instead.")]
+  public static System.DateTimeOffset? Convert(long? value);
+
+}
+```

--- a/public-api/MetaBrainz.Common.net8.0.cs.md
+++ b/public-api/MetaBrainz.Common.net8.0.cs.md
@@ -1,0 +1,139 @@
+﻿# API Reference: MetaBrainz.Common
+
+## Assembly Attributes
+
+```cs
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+```
+
+## Namespace: MetaBrainz.Common
+
+### Type: AsyncUtils
+
+```cs
+public static class AsyncUtils {
+
+  public static void ResultOf(System.Threading.Tasks.Task task);
+
+  public static void ResultOf(System.Threading.Tasks.ValueTask task);
+
+  public static T ResultOf<T>(System.Threading.Tasks.Task<T> task);
+
+  public static T ResultOf<T>(System.Threading.Tasks.ValueTask<T> task);
+
+}
+```
+
+### Type: HttpError
+
+```cs
+public class HttpError : System.Exception {
+
+  string Message {
+    public override get;
+  }
+
+  string? Reason {
+    public get;
+  }
+
+  System.Net.HttpStatusCode Status {
+    public get;
+  }
+
+  public HttpError(System.Net.Http.HttpResponseMessage response);
+
+  public HttpError(System.Net.HttpStatusCode status, string? reason, System.Exception? cause = null);
+
+}
+```
+
+### Type: HttpUtils
+
+```cs
+public static class HttpUtils {
+
+  public const string UnknownAssemblyName = "*Unknown Assembly*";
+
+  public static System.Net.Http.Headers.ProductInfoHeaderValue CreateUserAgentHeader<T>();
+
+  public static System.Net.Http.HttpResponseMessage EnsureSuccessful(this System.Net.Http.HttpResponseMessage response);
+
+  public static System.Threading.Tasks.ValueTask<System.Net.Http.HttpResponseMessage> EnsureSuccessfulAsync(this System.Net.Http.HttpResponseMessage response, System.Threading.CancellationToken cancellationToken = default);
+
+  public static string GetContentEncoding(this System.Net.Http.Headers.HttpContentHeaders contentHeaders);
+
+  public static string GetStringContent(this System.Net.Http.HttpResponseMessage response);
+
+  public static System.Threading.Tasks.Task<string> GetStringContentAsync(this System.Net.Http.HttpResponseMessage response, System.Threading.CancellationToken cancellationToken = default);
+
+}
+```
+
+### Type: RateLimitInfo
+
+```cs
+public readonly struct RateLimitInfo {
+
+  int? AllowedRequests {
+    public get;
+  }
+
+  System.DateTimeOffset LastRequest {
+    public get;
+  }
+
+  int? RemainingRequests {
+    public get;
+  }
+
+  System.DateTimeOffset? ResetAt {
+    public get;
+  }
+
+  int? ResetIn {
+    public get;
+  }
+
+  public RateLimitInfo(System.Net.Http.Headers.HttpResponseHeaders headers);
+
+}
+```
+
+### Type: TextUtils
+
+```cs
+public static class TextUtils {
+
+  [System.ObsoleteAttribute("Call Encoding.UTF8.GetString() instead.")]
+  public static string DecodeUtf8(System.ReadOnlySpan<byte> bytes);
+
+  public static string FormatMultiLine(string text, string prefix = "<<", string suffix = ">>", string separator = "\n  ");
+
+}
+```
+
+### Type: UnixTime
+
+```cs
+[System.ObsoleteAttribute("Use DateTimeOffset instead.")]
+public static class UnixTime {
+
+  [System.ObsoleteAttribute("Use DateTimeOffset.UnixEpoch instead.")]
+  public static readonly System.DateTimeOffset Epoch;
+
+  [System.ObsoleteAttribute("Use DateTimeOffset.ToUnixTimeSeconds instead.")]
+  public static long Convert(System.DateTimeOffset value);
+
+  [System.ObsoleteAttribute("Use DateTimeOffset.ToUnixTimeSeconds instead.")]
+  public static long? Convert(System.DateTimeOffset? value);
+
+  [System.ObsoleteAttribute("Use DateTimeOffset.FromUnixTimeSeconds instead.")]
+  public static System.DateTimeOffset Convert(long value);
+
+  [System.ObsoleteAttribute("Use DateTimeOffset.FromUnixTimeSeconds instead.")]
+  public static System.DateTimeOffset? Convert(long? value);
+
+}
+```


### PR DESCRIPTION
- set `AssemblyIsComVisible` to `false` in the project file
  - allows dropping the `AssemblyInfo.cs` file
- add "public API" reference files