### PR TITLE
More HTTP stuff

### DIFF
--- a/MetaBrainz.Common/HttpError.cs
+++ b/MetaBrainz.Common/HttpError.cs
@@ -39,10 +39,10 @@ public class HttpError : Exception {
     this.Version = version;
   }
 
-  /// <summary>The content (assumed to be text) of the response that triggered the error, if available.</summary>
+  /// <summary>The content (assumed to be text) of the error response, if available.</summary>
   public string? Content { get; private init; }
 
-  /// <summary>The content headers of the response that triggered the error, if available.</summary>
+  /// <summary>The content headers of the error response, if available.</summary>
   public HttpContentHeaders? ContentHeaders { get; private init; }
 
   /// <summary>Gets a textual representation of the HTTP error.</summary>
@@ -65,17 +65,23 @@ public class HttpError : Exception {
   /// <summary>The reason phrase associated with the error.</summary>
   public string? Reason { get; }
 
-  /// <summary>The headers of the response that triggered the error, if available.</summary>
+  /// <summary>The headers of the request that provoked the error response, if available.</summary>
+  public HttpRequestHeaders? RequestHeaders { get; private init; }
+
+  /// <summary>The URI for the request that provoked the error response, if available.</summary>
+  public Uri? RequestUri { get; private init; }
+
+  /// <summary>The headers of the error response, if available.</summary>
   public HttpResponseHeaders? ResponseHeaders { get; private init; }
 
   /// <summary>The status code for the error.</summary>
   public HttpStatusCode Status { get; }
 
-  /// <summary>The HTTP message version from the response that triggered the error, if available.</summary>
+  /// <summary>The HTTP message version from the error response, if available.</summary>
   public Version? Version { get; private init; }
 
   /// <summary>Creates a new HTTP error based on an response message.</summary>
-  /// <param name="response">The response message that triggered the error.</param>
+  /// <param name="response">The response.</param>
   /// <returns>A new HTTP error containing information taken from the response message.</returns>
   public static HttpError FromResponse(HttpResponseMessage response) => AsyncUtils.ResultOf(HttpError.FromResponseAsync(response));
 
@@ -88,6 +94,8 @@ public class HttpError : Exception {
     return new HttpError(response.StatusCode, response.ReasonPhrase) {
       Content = await response.GetStringContentAsync(cancellationToken),
       ContentHeaders = HttpUtils.Copy(response.Content.Headers),
+      RequestHeaders = HttpUtils.Copy(response.RequestMessage?.Headers),
+      RequestUri = response.RequestMessage?.RequestUri,
       ResponseHeaders = HttpUtils.Copy(response.Headers),
       Version = response.Version,
     };

--- a/MetaBrainz.Common/HttpError.cs
+++ b/MetaBrainz.Common/HttpError.cs
@@ -85,12 +85,10 @@ public class HttpError : Exception {
   /// <returns>A new HTTP error containing information taken from the response message.</returns>
   public static async Task<HttpError> FromResponseAsync(HttpResponseMessage response,
                                                         CancellationToken cancellationToken = default) {
-    // It's unfortunate that the headers are not easily copied (the classes do not have public constructors), so any changes to the
-    // response after this method is called will be reflected in the error's properties.
     return new HttpError(response.StatusCode, response.ReasonPhrase) {
       Content = await response.GetStringContentAsync(cancellationToken),
-      ContentHeaders = response.Content.Headers,
-      ResponseHeaders = response.Headers,
+      ContentHeaders = HttpUtils.Copy(response.Content.Headers),
+      ResponseHeaders = HttpUtils.Copy(response.Headers),
       Version = response.Version,
     };
   }

--- a/MetaBrainz.Common/HttpUtils.cs
+++ b/MetaBrainz.Common/HttpUtils.cs
@@ -1,6 +1,4 @@
-﻿#define TRACE
-
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;

--- a/MetaBrainz.Common/HttpUtils.cs
+++ b/MetaBrainz.Common/HttpUtils.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -17,6 +18,54 @@ namespace MetaBrainz.Common;
 /// <summary>Utility methods related to HTTP processing.</summary>
 [PublicAPI]
 public static class HttpUtils {
+
+  /// <summary>Creates a copy of a set of HTTP content headers.</summary>
+  /// <param name="headers">The headers to copy.</param>
+  /// <returns>A new set of HTTP content headers, with the same contents as the set provided.</returns>
+  [return: NotNullIfNotNull(nameof(headers))]
+  public static HttpContentHeaders? Copy(HttpContentHeaders? headers) {
+    if (headers is null) {
+      return null;
+    }
+    // There is no way to construct a copy of HTTP headers directly at the moment (see dotnet/runtime#95912).
+    using var dummy = new ByteArrayContent(Array.Empty<byte>());
+    HttpUtils.Copy(headers, dummy.Headers);
+    return dummy.Headers;
+  }
+
+  private static void Copy(HttpHeaders from, HttpHeaders to) {
+    foreach (var (name, values) in from.NonValidated) {
+      to.TryAddWithoutValidation(name, values);
+    }
+  }
+
+  /// <summary>Creates a copy of a set of HTTP request headers.</summary>
+  /// <param name="headers">The headers to copy.</param>
+  /// <returns>A new set of HTTP request headers, with the same contents as the set provided.</returns>
+  [return: NotNullIfNotNull(nameof(headers))]
+  public static HttpRequestHeaders? Copy(HttpRequestHeaders? headers) {
+    if (headers is null) {
+      return null;
+    }
+    // There is no way to construct a copy of HTTP headers directly at the moment (see dotnet/runtime#95912).
+    using var dummy = new HttpRequestMessage();
+    HttpUtils.Copy(headers, dummy.Headers);
+    return dummy.Headers;
+  }
+
+  /// <summary>Creates a copy of a set of HTTP response headers.</summary>
+  /// <param name="headers">The headers to copy.</param>
+  /// <returns>A new set of HTTP response headers, with the same contents as the set provided.</returns>
+  [return: NotNullIfNotNull(nameof(headers))]
+  public static HttpResponseHeaders? Copy(HttpResponseHeaders? headers) {
+    if (headers is null) {
+      return null;
+    }
+    // There is no way to construct a copy of HTTP headers directly at the moment (see dotnet/runtime#95912).
+    using var dummy = new HttpResponseMessage();
+    HttpUtils.Copy(headers, dummy.Headers);
+    return dummy.Headers;
+  }
 
   /// <summary>Create a user agent header containing the name and version of the assembly containing a particular type.</summary>
   /// <typeparam name="T">The type to use to determine the assembly name and version.</typeparam>

--- a/MetaBrainz.Common/MetaBrainz.Common.csproj
+++ b/MetaBrainz.Common/MetaBrainz.Common.csproj
@@ -11,7 +11,7 @@
     <PackageCopyrightYears>2022, 2023</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.Common</PackageRepositoryName>
     <PackageTags>MetaBrainz</PackageTags>
-    <Version>2.1.1-pre</Version>
+    <Version>2.2.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/MetaBrainz.Common/MetaBrainz.Common.csproj
+++ b/MetaBrainz.Common/MetaBrainz.Common.csproj
@@ -11,7 +11,7 @@
     <PackageCopyrightYears>2022, 2023</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.Common</PackageRepositoryName>
     <PackageTags>MetaBrainz</PackageTags>
-    <Version>2.2.0-pre</Version>
+    <Version>3.0.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/public-api/MetaBrainz.Common.net6.0.cs.md
+++ b/public-api/MetaBrainz.Common.net6.0.cs.md
@@ -38,10 +38,6 @@ public class HttpError : System.Exception {
     public get;
   }
 
-  string Message {
-    public override get;
-  }
-
   string? Reason {
     public get;
   }
@@ -66,12 +62,7 @@ public class HttpError : System.Exception {
     public get;
   }
 
-  [System.ObsoleteAttribute("Use FromResponse or FromResponseAsync instead.")]
-  public HttpError(System.Net.Http.HttpResponseMessage response);
-
-  public HttpError(System.Net.HttpStatusCode status, string? reason, System.Exception? cause = null);
-
-  public HttpError(System.Net.HttpStatusCode status, string? reason, System.Version version, System.Exception? cause = null);
+  public HttpError(System.Net.HttpStatusCode status, string? reason = null, System.Version? version = null, string? message = null, System.Exception? cause = null);
 
   public static HttpError FromResponse(System.Net.Http.HttpResponseMessage response);
 

--- a/public-api/MetaBrainz.Common.net6.0.cs.md
+++ b/public-api/MetaBrainz.Common.net6.0.cs.md
@@ -46,6 +46,14 @@ public class HttpError : System.Exception {
     public get;
   }
 
+  System.Net.Http.Headers.HttpRequestHeaders? RequestHeaders {
+    public get;
+  }
+
+  System.Uri? RequestUri {
+    public get;
+  }
+
   System.Net.Http.Headers.HttpResponseHeaders? ResponseHeaders {
     public get;
   }

--- a/public-api/MetaBrainz.Common.net6.0.cs.md
+++ b/public-api/MetaBrainz.Common.net6.0.cs.md
@@ -81,6 +81,15 @@ public static class HttpUtils {
 
   public const string UnknownAssemblyName = "*Unknown Assembly*";
 
+  [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("headers")]
+  public static System.Net.Http.Headers.HttpContentHeaders? Copy(System.Net.Http.Headers.HttpContentHeaders? headers);
+
+  [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("headers")]
+  public static System.Net.Http.Headers.HttpRequestHeaders? Copy(System.Net.Http.Headers.HttpRequestHeaders? headers);
+
+  [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("headers")]
+  public static System.Net.Http.Headers.HttpResponseHeaders? Copy(System.Net.Http.Headers.HttpResponseHeaders? headers);
+
   public static System.Net.Http.Headers.ProductInfoHeaderValue CreateUserAgentHeader<T>();
 
   public static System.Net.Http.HttpResponseMessage EnsureSuccessful(this System.Net.Http.HttpResponseMessage response);

--- a/public-api/MetaBrainz.Common.net8.0.cs.md
+++ b/public-api/MetaBrainz.Common.net8.0.cs.md
@@ -38,10 +38,6 @@ public class HttpError : System.Exception {
     public get;
   }
 
-  string Message {
-    public override get;
-  }
-
   string? Reason {
     public get;
   }
@@ -66,12 +62,7 @@ public class HttpError : System.Exception {
     public get;
   }
 
-  [System.ObsoleteAttribute("Use FromResponse or FromResponseAsync instead.")]
-  public HttpError(System.Net.Http.HttpResponseMessage response);
-
-  public HttpError(System.Net.HttpStatusCode status, string? reason, System.Exception? cause = null);
-
-  public HttpError(System.Net.HttpStatusCode status, string? reason, System.Version version, System.Exception? cause = null);
+  public HttpError(System.Net.HttpStatusCode status, string? reason = null, System.Version? version = null, string? message = null, System.Exception? cause = null);
 
   public static HttpError FromResponse(System.Net.Http.HttpResponseMessage response);
 

--- a/public-api/MetaBrainz.Common.net8.0.cs.md
+++ b/public-api/MetaBrainz.Common.net8.0.cs.md
@@ -46,6 +46,14 @@ public class HttpError : System.Exception {
     public get;
   }
 
+  System.Net.Http.Headers.HttpRequestHeaders? RequestHeaders {
+    public get;
+  }
+
+  System.Uri? RequestUri {
+    public get;
+  }
+
   System.Net.Http.Headers.HttpResponseHeaders? ResponseHeaders {
     public get;
   }

--- a/public-api/MetaBrainz.Common.net8.0.cs.md
+++ b/public-api/MetaBrainz.Common.net8.0.cs.md
@@ -81,6 +81,15 @@ public static class HttpUtils {
 
   public const string UnknownAssemblyName = "*Unknown Assembly*";
 
+  [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("headers")]
+  public static System.Net.Http.Headers.HttpContentHeaders? Copy(System.Net.Http.Headers.HttpContentHeaders? headers);
+
+  [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("headers")]
+  public static System.Net.Http.Headers.HttpRequestHeaders? Copy(System.Net.Http.Headers.HttpRequestHeaders? headers);
+
+  [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("headers")]
+  public static System.Net.Http.Headers.HttpResponseHeaders? Copy(System.Net.Http.Headers.HttpResponseHeaders? headers);
+
   public static System.Net.Http.Headers.ProductInfoHeaderValue CreateUserAgentHeader<T>();
 
   public static System.Net.Http.HttpResponseMessage EnsureSuccessful(this System.Net.Http.HttpResponseMessage response);


### PR DESCRIPTION
This adds `Copy` methods to `HttpUtils`, for copying HTTP header collections.

It also adjusts `HttpError`:

- it now retains the URI and headers for the request that provoked the error response (if available)
- it now has only a single constructor, which also allows specifying a message for the exception